### PR TITLE
Pre-commit improvements

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -47,8 +47,7 @@ jobs:
         uses: jupyterlab/maintainer-tools/.github/actions/base-setup@v1
       - name: Install the Python dependencies
         run: |
-          pip install -r requirements.txt
-          pip install pytest
+          pip install -r requirements-test.txt
       - name: Run the tests
         run: python -m pytest -vv -raXs || python -m pytest -vv -raXs --lf
       - name: Start the App

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,16 +12,6 @@ repos:
   - id: forbid-new-submodules
   - id: trailing-whitespace
 
-- repo: https://gitlab.com/pycqa/flake8
-  rev: 3.8.4
-  hooks:
-  - id: flake8
-    additional_dependencies: [
-        'flake8-bugbear==20.1.4',
-        'flake8-logging-format==0.6.0',
-        'flake8-implicit-str-concat==0.2.0',
-    ]
-
 - repo: https://github.com/psf/black
   rev: 22.1.0
   hooks:
@@ -34,6 +24,16 @@ repos:
   - id: isort
     files: \.py$
     args: [--profile=black]
+
+- repo: https://gitlab.com/pycqa/flake8
+  rev: 3.8.4
+  hooks:
+  - id: flake8
+    additional_dependencies: [
+        'flake8-bugbear==20.1.4',
+        'flake8-logging-format==0.6.0',
+        'flake8-implicit-str-concat==0.2.0',
+    ]
 
 - repo: https://github.com/sirosen/check-jsonschema
   rev: 0.10.2

--- a/README.md
+++ b/README.md
@@ -99,6 +99,8 @@ likely be killed. I haven't implemented a queue yet.
 If issued from a PR, will apply black to commits made in this PR and push
 the updated commits.
 
+You can also use "blackify" as an alias.
+
 Repo admins only, we plan to make it available to PR authors as well.
 
 MeeseeksDev Bot needs to be installed on the PR source repository for this to work.
@@ -109,6 +111,8 @@ If it's not it will ask you to do so.
 If issued from a PR, will apply pre-commit to this PR and push
 a commit with the changes made.  If no changes are made, or the changes
 cannot be automatically fixed, it will show a comment in the PR and bail.
+
+You can also use "precommit" as an alias.
 
 Repo admins only, we plan to make it available to PR authors as well.
 
@@ -161,6 +165,11 @@ Issuer needs at least write permission.
 
 If Mergeable, Merge current PR using said methods (`merge` if no arguments)
 
+## Command Extras
+
+You can be polite and use "please" with any of the commands, e.g. "@Meeseeksdev please close".
+
+You can optionally use the word "run" in the command, e.g. "@Meeseeksdev please run pre-commit".
 
 ## Simple extension.
 

--- a/meeseeksdev/__init__.py
+++ b/meeseeksdev/__init__.py
@@ -161,6 +161,7 @@ def main():
         "autopep8": blackify,
         "reformat": blackify,
         "black": blackify,
+        "blackify": blackify,
         "suggestions": black_suggest,
         "pre-commit": precommit,
         "precommit": precommit,

--- a/meeseeksdev/meeseeksbox/core.py
+++ b/meeseeksdev/meeseeksbox/core.py
@@ -71,11 +71,12 @@ class MainHandler(BaseHandler):
         self.finish("No")
 
 
-def _strip_please(c):
+def _strip_extras(c):
     if c.startswith("please "):
-        return c[6:].lstrip()
-    else:
-        return c
+        c = c[6:].lstrip()
+    if c.startswith("run "):
+        c = c[4:].lstrip()
+    return c
 
 
 def process_mentionning_comment(body, bot_re):
@@ -99,7 +100,7 @@ def process_mentionning_comment(body, bot_re):
         else:
             nl.append(bot_re.split(l)[-1].strip())
 
-    command_args = [_strip_please(l).split(" ", 1) for l in nl]
+    command_args = [_strip_extras(l).split(" ", 1) for l in nl]
     command_args = [c if len(c) > 1 else [c[0], None] for c in command_args]
     return command_args
 
@@ -112,7 +113,7 @@ class WebHookHandler(MainHandler):
         super().initialize(*args, **kwargs)
 
     def get(self):
-        self.getfinish("Webhook alive and listening")
+        self.finish("Webhook alive and listening")
 
     def post(self):
         if self.config.forward_staging_url:

--- a/meeseeksdev/tests/test_misc.py
+++ b/meeseeksdev/tests/test_misc.py
@@ -15,11 +15,19 @@ def test1():
         @meeseeksdev nothing
         @meeseeksdev[bot] do nothing
         meeseeksdev[bot] do something
+        @meeseeksdev please nothing
+        @meeseeksdev run something
 
 
     """
             ),
             reg,
         )
-        == [["nothing", None], ["do", "nothing"], ["do", "something"]]
+        == [
+            ["nothing", None],
+            ["do", "nothing"],
+            ["do", "something"],
+            ["nothing", None],
+            ["something", None],
+        ]
     )

--- a/meeseeksdev/tests/test_webhook.py
+++ b/meeseeksdev/tests/test_webhook.py
@@ -40,18 +40,16 @@ def app():
     return application
 
 
-@pytest.mark.gen_test
-def test_get(http_client, base_url):
-    response = yield http_client.fetch(base_url)
+async def test_get(http_server_client):
+    response = await http_server_client.fetch("/")
     assert response.code == 200
 
 
-@pytest.mark.gen_test
-def test_post(http_client, base_url):
+async def test_post(http_server_client):
     body = "{}"
     secret = config.webhook_secret
     assert secret is not None
     sig = "sha1=" + hmac.new(secret.encode("utf8"), body.encode("utf8"), "sha1").hexdigest()
     headers = {"X-Hub-Signature": sig}
-    response = yield http_client.fetch(base_url, method="POST", body=body, headers=headers)
+    response = await http_server_client.fetch("/", method="POST", body=body, headers=headers)
     assert response.code == 200

--- a/meeseeksdev/tests/test_webhook.py
+++ b/meeseeksdev/tests/test_webhook.py
@@ -1,0 +1,57 @@
+import hmac
+
+import pytest
+import tornado.web
+
+from ..meeseeksbox.core import Authenticator, Config, WebHookHandler
+
+commands = {}
+
+config = Config(
+    integration_id=100,
+    key=None,
+    personal_account_token="foo",
+    personal_account_name="bar",
+    forward_staging_url="",
+    webhook_secret="foo",
+)
+
+auth = Authenticator(
+    config.integration_id, config.key, config.personal_account_token, config.personal_account_name
+)
+
+application = tornado.web.Application(
+    [
+        (
+            r"/",
+            WebHookHandler,
+            {
+                "actions": commands,
+                "config": config,
+                "auth": auth,
+            },
+        ),
+    ]
+)
+
+
+@pytest.fixture
+def app():
+    return application
+
+
+@pytest.mark.gen_test
+def test_get(http_client, base_url):
+    response = yield http_client.fetch(base_url)
+    assert response.code == 200
+
+
+@pytest.mark.gen_test
+def test_post(http_client, base_url):
+    body = "{}"
+    secret = config.webhook_secret
+    assert secret is not None
+    sig = "sha1=" + hmac.new(secret.encode("utf8"), body.encode("utf8"), "sha1").hexdigest()
+    headers = {"X-Hub-Signature": sig}
+    response = yield http_client.fetch(base_url, method="POST", body=body, headers=headers)
+    assert response.code == 200

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,0 +1,3 @@
+-r ./requirements.txt
+pytest
+pytest-tornado

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,3 +1,3 @@
 -r ./requirements.txt
-pytest
-pytest-tornado
+pytest>=6.0
+pytest-tornasync


### PR DESCRIPTION
- Allow commands to accept a "run" prefix, e.g. `please run pre-commit`
- Add "acknowledge" comments when running `black` or `pre-commit` since they might take a while
- Don't error out on exit code when we can't auto-fix pre-commit - at least fix what we can but issue warning
- Add webhook tests

Tested against https://github.com/blink1073/jupyter_server/pull/6