### PR TITLE
Better auth handling

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,9 +26,15 @@ heroku git:remote -a meeseeksdev-$USER
 
 Then run:
 
-```
+```bash
 git push heroku $(git rev-parse --abbrev-ref HEAD):master
 heroku open
+```
+
+To view the logs in a terminal window, use:
+
+```bash
+heroku logs --app meeseeksdev=$USER -t
 ```
 
 ### GitHub App Configuration

--- a/meeseeksdev/meeseeksbox/commands.py
+++ b/meeseeksdev/meeseeksbox/commands.py
@@ -419,7 +419,9 @@ def push_the_work(session, payload, arguments, local_config=None):
     print(f"pushing with workbranch:{branch}")
     succeeded = True
     try:
-        repo.remotes.origin.push("workbranch:{}".format(branch), force=True).raise_if_error()
+        repo.remotes.origin.push(
+            "workbranch:{}".format(branch), force=True
+        ).raise_if_error()  # type:ignore[operator]
     except Exception:
         succeeded = False
 
@@ -957,7 +959,7 @@ If these instructions are inaccurate, feel free to [suggest an improvement](http
         succeeded = True
         try:
             print(f"Trying to push to {remote_submit_branch} of {session.personal_account_name}")
-            repo.remotes[session.personal_account_name].push(
+            repo.remotes[session.personal_account_name].push(  # type:ignore[operator]
                 "workbranch:{}".format(remote_submit_branch)
             ).raise_if_error()
         except Exception as e:

--- a/meeseeksdev/meeseeksbox/core.py
+++ b/meeseeksdev/meeseeksbox/core.py
@@ -575,9 +575,9 @@ class WebHookHandler(MainHandler):
                         gen = YieldBreaker(maybe_gen)
                         for org_repo in gen:
                             torg, trepo = org_repo.split("/")
-                            session_id = self.auth.idmap.get(org_repo)
-                            if session_id:
-                                target_session = self.auth.session(session_id)
+                            target_session = self.auth.get_session(org_repo)
+
+                            if target_session:
                                 # TODO, if PR, admin and request is on source repo, allows anyway.
                                 # we may need to also check allow edit from maintainer and provide
                                 # another decorator for safety.
@@ -631,7 +631,6 @@ class MeeseeksBox:
             self.config.personal_account_token,
             self.config.personal_account_name,
         )
-        self.auth._build_auth_id_mapping()
 
     def sig_handler(self, sig, frame):
         print(yellow, "Caught signal: %s, Shutting down..." % sig, normal)
@@ -675,4 +674,6 @@ class MeeseeksBox:
         clear_cache_callback = tornado.ioloop.PeriodicCallback(clear_caches, callback_time_ms)
         clear_cache_callback.start()
 
-        IOLoop.instance().start()
+        loop = IOLoop.instance()
+        loop.add_callback(self.auth._build_auth_id_mapping)
+        loop.start()


### PR DESCRIPTION
- Handle pagination in `list_installations` and when listing the repositories for an installation
- Store a mapping of installation -> org so we can update when a new repo is added
- Defer building the auth map until after the application has started - we only have 60 seconds to fully start

Tested on my dev meeseeks installation.