### PR TITLE
FIX: missed renames from mypy adoption

### DIFF
--- a/meeseeksdev/meeseeksbox/core.py
+++ b/meeseeksdev/meeseeksbox/core.py
@@ -351,7 +351,7 @@ class WebHookHandler(MainHandler):
                         if milestone:
                             description.append(milestone.get("description", "") or "")
                         description_str = "\n".join(description)
-                        if "on-merge:" in description and is_pr["base"]["ref"] in (
+                        if "on-merge:" in description_str and is_pr["base"]["ref"] in (
                             "master",
                             "main",
                         ):
@@ -371,13 +371,13 @@ class WebHookHandler(MainHandler):
                                     '"on-merge:" found in milestone description, but unable to parse command.',
                                     'Is "on-merge:" on a separate line?',
                                 )
-                                print(description)
+                                print(description_str)
                         else:
                             print(
                                 f'PR is not targeting main/master branch ({is_pr["base"]["ref"]}),'
                                 'or "on-merge:" not in milestone (or label) description:'
                             )
-                            print(description)
+                            print(description_str)
                     else:
                         print(f"({repo}) Hum, closed, PR but not merged")
                 else:


### PR DESCRIPTION
need to search for "on-merge:" in description_str (which is a string) not in
description (which is still a list that contains strings that may contain
"on-merge:")

We noticed this on Matplotlib.